### PR TITLE
Update repository links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": {
     "name": "Shane Osbourne"
   },
-  "repository": "shakyshane/browser-sync-ui",
+  "repository": "BrowserSync/UI",
   "files": [
     "index.js",
     "lib",
@@ -17,7 +17,7 @@
   "licenses": [
     {
       "type": "Apache-2.0",
-      "url": "https://github.com/shakyshane/browser-sync-ui/blob/master/LICENSE"
+      "url": "https://github.com/BrowserSync/UI/blob/master/LICENSE"
     }
   ],
   "engines": {


### PR DESCRIPTION
Dead links that were pointing at the old repository. Was causing issues when trying to use [WebJars](https://github.com/webjars/webjars).