### PR TITLE
Correct network throttle labels

### DIFF
--- a/lib/plugins/network-throttle/targets.js
+++ b/lib/plugins/network-throttle/targets.js
@@ -1,7 +1,7 @@
 module.exports = [
     {
         active:  false,
-        title:   "DSL (2Mbps, 5ms RTT)",
+        title:   "DSL (2Mbs, 5ms RTT)",
         id:      "dsl",
         speed:   200,
         latency: 5,
@@ -10,7 +10,7 @@ module.exports = [
     },
     {
         active:  false,
-        title:   "4G (750kbs, 100ms RTT)",
+        title:   "4G (4Mbs, 20ms RTT)",
         id:     "4g",
         speed:   400,
         latency: 10,


### PR DESCRIPTION
- Correct 4G data.
- Change "Mbps" to "Mbs" for consistency with "kbs".