### PR TITLE
Fix Network Throttle TypeError with HTTPS (fix #43)

### DIFF
--- a/lib/plugins/network-throttle/network-throttle.js
+++ b/lib/plugins/network-throttle/network-throttle.js
@@ -87,9 +87,9 @@ module.exports.init = function (ui) {
                 };
 
                 if (ui.bs.getOption("scheme") === "https") {
-                    var certs = require("browser-sync/lib/server/utils").getKeyAndCert(ui.bs.options);
-                    args.key  = certs.key;
-                    args.cert = certs.cert;
+                    var httpsOpts = require("browser-sync/lib/server/utils").getHttpsOptions(ui.bs.options);
+                    args.key  = httpsOpts.key;
+                    args.cert = httpsOpts.cert;
                 }
 
                 args.server = require("./throttle-server")(args);


### PR DESCRIPTION
The `getKeyAndCert` method does not exist, so calling it causes a TypeError (see #43). This PR fixes that by calling `getHttpsOptions` instead, which results in the correct key and cert to be returned.