### PR TITLE
Fix addCss function export

### DIFF
--- a/lib/client-js.js
+++ b/lib/client-js.js
@@ -66,7 +66,7 @@
 
     bs.addDomNode = addDomNode;
     bs.addJs      = addJs;
-    bs.addCss     = addJs;
+    bs.addCss     = addCss;
 
     function addJs(data) {
         (function (e) {


### PR DESCRIPTION
It seems to be unintentional to export `addJs` as `addCss`, so here is the fix.