### PR TITLE
fix: a typo with codeSync tagline

### DIFF
--- a/lib/plugins/sync-options/sync-options.client.js
+++ b/lib/plugins/sync-options/sync-options.client.js
@@ -60,7 +60,7 @@
             "ghostMode.submit":  "Form Submissions will be synced",
             "ghostMode.inputs":  "Text inputs (including text-areas) will be synced",
             "ghostMode.toggles": "Radio + Checkboxes changes will be synced",
-            codeSync:            "Reload or Inject files they change"
+            codeSync:            "Reload or Inject files that change"
         };
 
         // If watching files, add the code-sync toggle


### PR DESCRIPTION
Found a typo while viewing the ui in browser sync. I think this was the intended word.